### PR TITLE
fix volatile warning

### DIFF
--- a/FlowNet2_src/models/flownet2.py
+++ b/FlowNet2_src/models/flownet2.py
@@ -107,13 +107,14 @@ class FlowNet2(nn.Module):
         norm_flownets2_flow = self.channelnorm(flownets2_flow)
 
         diff_flownets2_flow = self.resample4(x[:, 3:, :, :], flownets2_flow)
-        if not diff_flownets2_flow.volatile:
+        req_grad = diff_flownets2_flow.requires_grad
+        if req_grad:
             diff_flownets2_flow.register_hook(
                 save_grad(self.grads, 'diff_flownets2_flow'))
 
         diff_flownets2_img1 = self.channelnorm(
             (x[:, :3, :, :] - diff_flownets2_flow))
-        if not diff_flownets2_img1.volatile:
+        if req_grad:
             diff_flownets2_img1.register_hook(
                 save_grad(self.grads, 'diff_flownets2_img1'))
 
@@ -123,13 +124,13 @@ class FlowNet2(nn.Module):
         norm_flownetsd_flow = self.channelnorm(flownetsd_flow)
 
         diff_flownetsd_flow = self.resample3(x[:, 3:, :, :], flownetsd_flow)
-        if not diff_flownetsd_flow.volatile:
+        if req_grad:
             diff_flownetsd_flow.register_hook(
                 save_grad(self.grads, 'diff_flownetsd_flow'))
 
         diff_flownetsd_img1 = self.channelnorm(
             (x[:, :3, :, :] - diff_flownetsd_flow))
-        if not diff_flownetsd_img1.volatile:
+        if req_grad:
             diff_flownetsd_img1.register_hook(
                 save_grad(self.grads, 'diff_flownetsd_img1'))
 
@@ -142,7 +143,7 @@ class FlowNet2(nn.Module):
             dim=1)
         flownetfusion_flow = self.flownetfusion(concat3)
 
-        if not flownetfusion_flow.volatile:
+        if req_grad:
             flownetfusion_flow.register_hook(
                 save_grad(self.grads, 'flownetfusion_flow'))
 

--- a/demo.py
+++ b/demo.py
@@ -1,3 +1,5 @@
+import matplotlib
+matplotlib.use('Agg')
 import numpy as np
 from scipy.misc import imread
 import torch
@@ -15,6 +17,7 @@ if __name__ == '__main__':
   # B x 3(RGB) x 2(pair) x H x W
   ims = np.array([[im1, im2]]).transpose((0, 4, 1, 2, 3)).astype(np.float32)
   ims = torch.from_numpy(ims)
+  print(ims.size())
   ims_v = Variable(ims.cuda(), requires_grad=False)
 
   # Build model
@@ -33,4 +36,4 @@ if __name__ == '__main__':
 
   # Visualization
   plt.imshow(flow_im)
-  plt.show()
+  plt.savefig('flow.png', bbox_inches='tight')


### PR DESCRIPTION
`volatile` is being removed from pytorch, so the inference scripts no longer work because the current code will try to add backwards hooks to the network that has `requires_grad == False`.  This pull requests checks for `requires_grad` instead of `volatile`.

Also not completely related, but I made the demo headless.  I ran the demo on an aws server and got an error.  I think the headless version makes more sense since it would also correctly output an image for setups that currently have a display. 